### PR TITLE
linting: Fix indentation of comments for _variables.scss

### DIFF
--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,13 +1,12 @@
-	// Variables
+// Variables
 
-	// To stay consistent, we set as many properties as variables as we can. We
-	// have five(???) options for margins and paddings and a something-point
-	// typographic scale. All colours should be defined in this file except #fff
-	// and #000.
+// To stay consistent, we set as many properties as variables as we can.
+// We have five(???) options for margins and paddings and a something-point typographic scale.
+// All colours should be defined in this file except #fff and #000.
 
-	// Look in utilities.scss for ways to use these same properties in html instead.
+// Look in utilities.scss for ways to use these same properties in html instead.
 
-	// Always use these variables when building components.
+// Always use these variables when building components.
 
 // Colours
 $black: #2F323B;


### PR DESCRIPTION
Fix indentation of comments for _variables.scss file to put repo
in compliance with linting rules.