### PR TITLE
lint: Abstract lint operation from sass compile.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,21 +32,33 @@ gulp.task('serve', ['styles'], function() {
 
 /*
 
-  ## gulp styles
+	## gulp style linting
 
-  1. Lint scss and log errors to console
-  2. Compile sass
-  3. Add minified, versioned(TODO) file to /dist folder
-  4. Inject into browser with BrowserSync
+	1. Lint sass and log any errors to the console.
+	2. Ignore defaults.scss and reset.scss
 
 */
 
-gulp.task('styles', function () {
+gulp.task('lint', function() {
+	return gulp.src(['./src/scss/*.scss', '!./src/scss/_defaults.scss', '!./src/scss/_reset.scss'])
+	.pipe(stylelint({
+		failAfterError: false,
+		reporters: [{formatter: 'string', console: true}]
+  }));
+});
+
+/*
+
+  ## gulp styles
+
+  1. Compile sass
+  2. Add minified, versioned(TODO) file to /dist folder
+  3. Inject into browser with BrowserSync
+
+*/
+
+gulp.task('styles', ['lint'], function () {
   return gulp.src('./src/scss/*.scss')
-    .pipe(stylelint({
-    	failAfterError: false,
-      	reporters: [{formatter: 'string', console: true}]
-    }))
     .pipe(sass({includePaths: neat, outputStyle: 'compact'}).on('error', sass.logError))
     .pipe(gulp.dest('./src/'))
     .pipe(browserSync.stream());

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,12 @@ gulp.task('serve', ['styles'], function() {
 */
 
 gulp.task('lint', function() {
-	return gulp.src(['./src/scss/*.scss', '!./src/scss/_defaults.scss', '!./src/scss/_reset.scss'])
+	return gulp.src([
+		'./src/scss/*.scss',
+		'!./src/scss/_defaults.scss',
+		'!./src/scss/_reset.scss',
+		'!./src/scss/_variables.scss'
+	])
 	.pipe(stylelint({
 		failAfterError: false,
 		reporters: [{formatter: 'string', console: true}]

--- a/src/style.css
+++ b/src/style.css
@@ -104,7 +104,7 @@ html { box-sizing: border-box; }
 
 .box *:last-child:not(input):not(textarea) { margin-bottom: 0; }
 
-body { background: #f7f7f7; -webkit-font-smoothing: antialiased; font-feature-settings: "liga", "dlig"; color: #2F323B; font-family: "Proxima Nova", sans-serif; }
+body { background: #f7f7f7; font-smoothing: antialiased; font-feature-settings: "liga", "dlig"; color: #2F323B; font-family: "Proxima Nova", sans-serif; }
 
 h1, h2, h3, h4 { font-family: "Ubuntu", sans-serif; font-weight: 100; line-height: 1.6; }
 


### PR DESCRIPTION
Abstract linting operation from sass compiling to allow
for ignoring of particular files. Certain files will
inherently have to break certain linting rules (like
type selectors), so this will allow us to ignore any
files where this may occur.

ref: UX-686