### PR TITLE
utilities: Add text transform styles.

### DIFF
--- a/src/scss/utilities/_typography.scss
+++ b/src/scss/utilities/_typography.scss
@@ -52,6 +52,10 @@
 .t-decoration-none {text-decoration: none}
 .t-italic {font-weight: italic}
 
+// Transforms
+.t-uppercase {text-transform: uppercase !important}
+.t-transform-none {text-transform: none !important}
+
 // Line Height
 .t-line-height-1 {line-height: 1 !important}
 

--- a/src/scss/utilities/_typography.scss
+++ b/src/scss/utilities/_typography.scss
@@ -53,7 +53,7 @@
 .t-italic {font-weight: italic}
 
 // Transforms
-.t-uppercase {text-transform: uppercase !important}
+.t-transform-uppercase {text-transform: uppercase !important}
 .t-transform-none {text-transform: none !important}
 
 // Line Height

--- a/src/style.css
+++ b/src/style.css
@@ -605,7 +605,7 @@ Utilities
 
 .t-italic { font-weight: italic; }
 
-.t-uppercase { text-transform: uppercase !important; }
+.t-transform-uppercase { text-transform: uppercase !important; }
 
 .t-transform-none { text-transform: none !important; }
 

--- a/src/style.css
+++ b/src/style.css
@@ -605,6 +605,10 @@ Utilities
 
 .t-italic { font-weight: italic; }
 
+.t-uppercase { text-transform: uppercase !important; }
+
+.t-transform-none { text-transform: none !important; }
+
 .t-line-height-1 { line-height: 1 !important; }
 
 .border, .form__input, tbody tr { border: 1px solid #f7f7f7 !important; }


### PR DESCRIPTION
Add text transform styles for when we want to uppercase
something or cancel something that is being transformed
by default.

Ref: UX-753