### PR TITLE
update stylelint and sass to work with newest node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-	"name": "dreamhost-css",
-	"version": "0.0.1",
-	"description": "DreamHost's CSS framework",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/dreamhost/dreamhost.css.git"
-	},
-	"dependencies": {
-		"node-neat": "1.7.2"
-	},
-	"devDependencies": {
-		"gulp": "3.9",
-		"gulp-autoprefixer": "^3.1.1",
-		"gulp-clean-css": "2.0.13",
-		"gulp-rename": "1.2.2",
-		"gulp-sass": "2.3",
-		"gulp-stylelint": "3.4.0",
-		"browser-sync": "2.18.1"
-	},
-	"private": true,
-	"license": "Unlicensed"
+  "name": "dreamhost-css",
+  "version": "0.0.1",
+  "description": "DreamHost's CSS framework",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dreamhost/dreamhost.css.git"
+  },
+  "dependencies": {
+    "node-neat": "1.7.2"
+  },
+  "devDependencies": {
+    "browser-sync": "2.18.1",
+    "gulp": "3.9",
+    "gulp-autoprefixer": "^3.1.1",
+    "gulp-clean-css": "2.0.13",
+    "gulp-rename": "1.2.2",
+    "gulp-sass": "^2.3.2",
+    "gulp-stylelint": "^3.7.0"
+  },
+  "private": true,
+  "license": "Unlicensed"
 }


### PR DESCRIPTION
I updated a couple plugins that were out of date because I couldn't compile CSS. Would recommend.

Code changes were from `npm install --save-dev`. Not manually edited