### PR TITLE
Add header tag classes.

### DIFF
--- a/framework/src/scss/_defaults.scss
+++ b/framework/src/scss/_defaults.scss
@@ -17,22 +17,22 @@ h1, h2, h3, h4 {
 	font-weight: 600;
 }
 
-h1 {
+h1, .t-h1 {
 	font-size: $t-xxl;
 	margin-bottom: $s-l;
 }
 
-h2 {
+h2, .t-h2 {
 	font-size: $t-l;
 	margin-bottom: $s-m;
 }
 
-h3 {
+h3, .t-h3 {
 	font-size: $t-l;
 	margin-bottom: $s-s;
 }
 
-h4 {
+h4, .t-h4 {
 	font-size: $t-m;
 	margin-bottom: $s-s;
 }


### PR DESCRIPTION
Add classes so header styling can be applied to text
without needing to use the actual tag. Named to
follow text-based class convention and also so
new classes won't stomp on anything else.