### PR TITLE
Remove tshirt sizes completely

### DIFF
--- a/framework/index.html
+++ b/framework/index.html
@@ -53,7 +53,7 @@
 								<li><a href="#">Logout</a></li>
 							</ul>
 						</div>
-						<form action="?" class="popover__section popover__section--separator bg-light-yellow t-xs p-1">
+						<form action="?" class="popover__section popover__section--separator bg-light-yellow t-1 p-1">
 							<label>Switch to user</label>
 							<input type="text" name="switch_to_user" value="" maxlength="32" size="10" autofocus="">
 							<a href="#" class="l-block m-top-1">Back to your account</a>
@@ -430,7 +430,7 @@
 					</ul>
 				</div>
 			</div>
-			<a class="btn js-toggle-popover scale-down-hover tr-duration tr-easing-ease">Top Popover</a>
+			<a class="btn js-toggle-popover scale-down-hover tr-duration-3 tr-easing-ease">Top Popover</a>
 		</div>
 	</section>
 	<h1>Page title</h1>
@@ -482,18 +482,19 @@
 
 	<section class="box m-bottom-5">
 		<h1>Typography</h1>
-		<p class="t-l">Large non-heading text!</p>
+		<p class="t-4">Large non-heading text!</p>
 		<h2>Heading two</h2>
 		<h3>Heading three</h3>
 		<h4>Heading four</h4>
 		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magni quidem mollitia optio temporibus cum eius deserunt, eum tenetur minima nulla hic inventore quo tempore reprehenderit. Laboriosam maiores odio debitis, in?</p>
 
 		<h2>Sizes</h2>
-		<p class="t-xl">.t-xl</p>
-		<p class="t-l">.t-l</p>
-		<p class="t-m">.t-m</p>
-		<p class="t-s">.t-s</p>
-		<p class="t-xl">.t-xs</p>
+		<p class="t-6">.t-6</p>
+		<p class="t-5">.t-5</p>
+		<p class="t-4">.t-4</p>
+		<p class="t-3">.t-3</p>
+		<p class="t-2">.t-2</p>
+		<p class="t-1">.t-1</p>
 		<ul class="list">
 			<li>List item</li>
 			<li>List item</li>
@@ -544,7 +545,7 @@
 					<p class="m-bottom-1">
 						<a href="#">Server Name</a>
 					</p>
-					<ul class="list list--inline m-0 t-s t-grey">
+					<ul class="list list--inline m-0 t-2 t-grey">
 						<li>VCPU: 1</li>
 						<li>RAM: 512MB</li>
 					</ul>
@@ -559,7 +560,7 @@
 					<p class="m-bottom-1">
 						<a href="#">Server Name</a>
 					</p>
-					<ul class="list list--inline m-0 t-s t-grey">
+					<ul class="list list--inline m-0 t-2 t-grey">
 						<li>VCPU: 1</li>
 						<li>RAM: 512MB</li>
 					</ul>
@@ -574,7 +575,7 @@
 					<p class="m-bottom-1">
 						<a href="#">Server Name</a>
 					</p>
-					<ul class="list list--inline m-0 t-s t-grey">
+					<ul class="list list--inline m-0 t-2 t-grey">
 						<li>VCPU: 1</li>
 						<li>RAM: 512MB</li>
 					</ul>
@@ -646,7 +647,7 @@
 			<p class="t-white">Normal rounded corners</p>
 		</div>
 
-		<div class="g-1_3 g-omega box m-bottom-4 u-border-radius-l bg-dark-grey">
+		<div class="g-1_3 g-omega box m-bottom-4 u-border-radius bg-dark-grey">
 			<p class="t-white">Large rounded corners</p>
 		</div>
 	</section>

--- a/framework/src/scss/_defaults.scss
+++ b/framework/src/scss/_defaults.scss
@@ -19,22 +19,22 @@ h1, h2, h3, h4,
 }
 
 h1, .h1 {
-	font-size: $t-xxl;
+	font-size: $t-6;
 	margin-bottom: convertScaleToRem(5);
 }
 
 h2, .h2 {
-	font-size: $t-xl;
+	font-size: $t-5;
 	margin-bottom: convertScaleToRem(4);
 }
 
 h3, .h3 {
-	font-size: $t-l;
+	font-size: $t-4;
 	margin-bottom: convertScaleToRem(3);
 }
 
 h4, .h4 {
-	font-size: $t-m;
+	font-size: $t-3;
 	margin-bottom: convertScaleToRem(3);
 }
 
@@ -76,7 +76,7 @@ hr {
 
 code {
 	padding: 0 convertScaleToRem(1);
-	font-size: $t-s;
+	font-size: $t-2;
 	display: inline-block;
 	border: 1px solid $lighter-grey;
 	border-radius: $border-radius;

--- a/framework/src/scss/_deprecate.scss
+++ b/framework/src/scss/_deprecate.scss
@@ -93,3 +93,11 @@
 .u-border-radius-l--right {@extend .u-border-radius--right;}
 .u-border-radius-l--bottom {@extend .u-border-radius--bottom;}
 .u-border-radius-l--left {@extend .u-border-radius--left;}
+
+// Depreciate text-size tshirt classes
+.t-xs {@extend .t-1;}
+.t-s {@extend .t-2;}
+.t-m {@extend .t-3;}
+.t-l {@extend .t-4;}
+.t-xl {@extend .t-5;}
+.t-xxl {@extend .t-6;}

--- a/framework/src/scss/_deprecate.scss
+++ b/framework/src/scss/_deprecate.scss
@@ -101,3 +101,11 @@
 .t-l {@extend .t-4;}
 .t-xl {@extend .t-5;}
 .t-xxl {@extend .t-6;}
+
+// Depreciate animation tshirt classes
+.a-duration-none {@extend .a-duration-0;}
+.a-duration-xs {@extend .a-duration-1;}
+.a-duration-s {@extend .a-duration-2;}
+.a-duration, .a-duration-m {@extend .a-duration-3;}
+.a-duration-l {@extend .a-duration-4;}
+.a-duration-xl {@extend .a-duration-5;}

--- a/framework/src/scss/_deprecate.scss
+++ b/framework/src/scss/_deprecate.scss
@@ -82,3 +82,14 @@
 .m-y,.m-x-m { @extend .m-x-4;}
 .m-x-l { @extend .m-x-5;}
 .m-x-xl { @extend .m-x-6;}
+
+// Depreciate 5px border-radius
+.u-border-radius-l {@extend .u-border-radius;}
+.u-border-radius-l--top-left {@extend .u-border-radius--top-left;}
+.u-border-radius-l--top-right {@extend .u-border-radius--top-right;}
+.u-border-radius-l--bottom-right {@extend .u-border-radius--bottom-right;}
+.u-border-radius-l--bottom-left {@extend .u-border-radius--bottom-left;}
+.u-border-radius-l--top {@extend .u-border-radius--top;}
+.u-border-radius-l--right {@extend .u-border-radius--right;}
+.u-border-radius-l--bottom {@extend .u-border-radius--bottom;}
+.u-border-radius-l--left {@extend .u-border-radius--left;}

--- a/framework/src/scss/_deprecate.scss
+++ b/framework/src/scss/_deprecate.scss
@@ -1,4 +1,4 @@
-// Depricate tshirt classes
+// Deprecate tshirt classes
 .p-xs { @extend .p-1;}
 .p-s { @extend .p-3;}
 .p,.p-m { @extend .p-4;}
@@ -83,7 +83,7 @@
 .m-x-l { @extend .m-x-5;}
 .m-x-xl { @extend .m-x-6;}
 
-// Depreciate 5px border-radius
+// Deprecate 5px border-radius
 .u-border-radius-l {@extend .u-border-radius;}
 .u-border-radius-l--top-left {@extend .u-border-radius--top-left;}
 .u-border-radius-l--top-right {@extend .u-border-radius--top-right;}
@@ -94,7 +94,7 @@
 .u-border-radius-l--bottom {@extend .u-border-radius--bottom;}
 .u-border-radius-l--left {@extend .u-border-radius--left;}
 
-// Depreciate text-size tshirt classes
+// Deprecate text-size tshirt classes
 .t-xs {@extend .t-1;}
 .t-s {@extend .t-2;}
 .t-m {@extend .t-3;}
@@ -102,7 +102,7 @@
 .t-xl {@extend .t-5;}
 .t-xxl {@extend .t-6;}
 
-// Depreciate animation tshirt classes
+// Deprecate animation tshirt classes
 .a-duration-none {@extend .a-duration-0;}
 .a-duration-xs {@extend .a-duration-1;}
 .a-duration-s {@extend .a-duration-2;}

--- a/framework/src/scss/_deprecate.scss
+++ b/framework/src/scss/_deprecate.scss
@@ -109,3 +109,10 @@
 .a-duration, .a-duration-m {@extend .a-duration-3;}
 .a-duration-l {@extend .a-duration-4;}
 .a-duration-xl {@extend .a-duration-5;}
+
+// Deprecate transition tshirt classes
+.tr-duration-xs {@extend .tr-duration-1;}
+.tr-duration-s {@extend .tr-duration-2;}
+.tr-duration, .tr-duration-m {@extend .tr-duration-3;}
+.tr-duration-l {@extend .tr-duration-4;}
+.tr-duration-xl {@extend .tr-duration-5;}

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -93,7 +93,6 @@ $t-heavy: 900;
 
 // Borders
 $border-radius: 3px;
-$border-radius-l: 5px;
 
 // Border size
 $border-size: 2px;

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -105,11 +105,11 @@ $a-2: .5s;
 $a-1: .3s;
 
 // Transition Duration
-$tr-xl: .3s;
-$tr-l: .2s;
-$tr-m: .1s;
-$tr-s: .07s;
-$tr-xs: .05s;
+$tr-5: .3s;
+$tr-4: .2s;
+$tr-3: .1s;
+$tr-2: .07s;
+$tr-1: .05s;
 
 // Z-indexes
 $z-0: -1;

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -78,12 +78,12 @@ $maxSize: 16; // Build 16 increments, 128px
 $body: 'Proxima Nova', sans-serif;
 $heading: 'Ubuntu', sans-serif;
 
-$t-xxl: 2.5rem; // 40px
-$t-xl: 2rem; // 32px
-$t-l: 1.5rem; // 24px
-$t-m: 1rem; // 16px
-$t-s: .875rem; // 14px. legibility at small sizes > adhering to scales
-$t-xs: .75em; // 12px
+$t-6: 2.5rem; // 40px
+$t-5: 2rem; // 32px
+$t-4: 1.5rem; // 24px
+$t-3: 1rem; // 16px
+$t-2: .875rem; // 14px. legibility at small sizes > adhering to scales
+$t-1: .75em; // 12px
 
 // Font weight
 $t-lighter: 100;

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -98,11 +98,11 @@ $border-radius: 3px;
 $border-size: 2px;
 
 // Animation Duration
-$a-xl: 2s;
-$a-l: 1.5s;
-$a-m: 1s;
-$a-s: .5s;
-$a-xs: .3s;
+$a-5: 2s;
+$a-4: 1.5s;
+$a-3: 1s;
+$a-2: .5s;
+$a-1: .3s;
 
 // Transition Duration
 $tr-xl: .3s;

--- a/framework/src/scss/components/_animations.scss
+++ b/framework/src/scss/components/_animations.scss
@@ -18,77 +18,77 @@ Animation Components
 // Spin
 .spin-right,
 .spin-right-hover:hover {
-	animation: spinRight $a-m 1 linear;
+	animation: spinRight $a-3 1 linear;
 	animation-fill-mode: forwards;
 }
 
 .spin-left,
 .spin-left-hover:hover {
-	animation: spinRight $a-m 1 linear reverse;
+	animation: spinRight $a-3 1 linear reverse;
 	animation-fill-mode: forwards;
 }
 
 // Bounce
 .bounce,
 .bounce-hover:hover {
-	animation: bounce $a-m 1 cubic-bezier(.075,.82,.165,1);
+	animation: bounce $a-3 1 cubic-bezier(.075,.82,.165,1);
 	animation-fill-mode: forwards;
 }
 
 // Shake
 .shake,
 .shake-hover:hover {
-	animation: shake $a-m 1 cubic-bezier(.075,.82,.165,1);
+	animation: shake $a-3 1 cubic-bezier(.075,.82,.165,1);
 	animation-fill-mode: forwards;
 }
 
 // Fade
 .fade-in,
 .fade-in-hover:hover {
-	animation: fadeIn $a-m 1 linear;
+	animation: fadeIn $a-3 1 linear;
 	animation-fill-mode: forwards;
 }
 
 .fade-out,
 .fade-out-hover:hover {
-	animation: fadeIn $a-m 1 linear reverse;
+	animation: fadeIn $a-3 1 linear reverse;
 	animation-fill-mode: forwards;
 }
 
 // slide
 .slide-in,
 .slide-in-hover:hover {
-	animation: slideIn $a-m 1 cubic-bezier(0.165,0.84,0.44,1);
+	animation: slideIn $a-3 1 cubic-bezier(0.165,0.84,0.44,1);
 	animation-fill-mode: forwards;
 }
 
 .slide-out,
 .slide-out-hover:hover {
-	animation: slideIn $a-m 1 linear reverse;
+	animation: slideIn $a-3 1 linear reverse;
 	animation-fill-mode: forwards;
 }
 
 .slide-up,
 .slide-up-hover:hover {
-	animation: slideUp $a-xs 1 linear;
+	animation: slideUp $a-1 1 linear;
 	animation-fill-mode: forwards;
 }
 
 .slide-down,
 .slide-down-hover:hover {
-	animation: slideDown $a-xs 1 linear reverse;
+	animation: slideDown $a-1 1 linear reverse;
 	animation-fill-mode: forwards;
 }
 
 .slide-left,
 .slide-left-hover:hover {
-	animation: slideLeft $a-xs 1 linear;
+	animation: slideLeft $a-1 1 linear;
 	animation-fill-mode: forwards;
 }
 
 .slide-right,
 .slide-right-hover:hover {
-	animation: slideRight $a-xs 1 linear reverse;
+	animation: slideRight $a-1 1 linear reverse;
 	animation-fill-mode: forwards;
 }
 

--- a/framework/src/scss/components/_buttons.scss
+++ b/framework/src/scss/components/_buttons.scss
@@ -35,7 +35,7 @@ Styleguide Base.buttons
 	border: none;
 	border-radius: 3px;
 	display: inline-block;
-	font-size: $t-m;
+	font-size: $t-3;
 	line-height: 1;
 	padding: .8em 1em .7em;
 	text-align: center;
@@ -151,7 +151,7 @@ Styleguide Base.buttons
 }
 
 // Sizes
-.btn--small { font-size: $t-xs; }
+.btn--small { font-size: $t-1; }
 .btn--large { font-size: 1.25rem; }
 
 // Widths

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -56,7 +56,7 @@ Form Component
 	margin: 0;
 	width: 100%;
 
-	border-radius: $border-radius-l;
+	border-radius: $border-radius;
 	padding: .65rem;
 
 	&::placeholder {

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -7,12 +7,12 @@ Form Component
 %form-border { border: 1px solid $light-grey; }
 %form-description {
 	color: $dark-grey;
-	font-size: $t-s;
+	font-size: $t-2;
 }
 %form-no-outline { outline: none; }
 %form-text-style {
 	color: $black;
-	font-size: $t-m;
+	font-size: $t-3;
 	font-family: $body;
 }
 
@@ -34,7 +34,7 @@ Form Component
 .form__label {
 	color: $darker-grey;
 	display: block;
-	font-size: $t-s;
+	font-size: $t-2;
 	font-weight: $t-bold;
 	margin-bottom: convertScaleToRem(1);
 }

--- a/framework/src/scss/components/_lists.scss
+++ b/framework/src/scss/components/_lists.scss
@@ -35,7 +35,7 @@
 	display: block;
 	padding: convertScaleToRem(1) convertScaleToRem(2);
 
-	transition-duration: $tr-m;
+	transition-duration: $tr-3;
 	transition-timing-function: linear
 }
 

--- a/framework/src/scss/components/_lists.scss
+++ b/framework/src/scss/components/_lists.scss
@@ -44,7 +44,7 @@
 	font-weight: $t-bold;
 	color: $black;
 	text-decoration: none;
-	font-size: $t-s;
+	font-size: $t-2;
 }
 
 // Don't give hover states to non-links

--- a/framework/src/scss/components/_page-header.scss
+++ b/framework/src/scss/components/_page-header.scss
@@ -92,7 +92,7 @@ Page Header Component
 	text-decoration: none;
 	font-weight: $t-bold;
 	color: $light-grey;
-	font-size: $t-s;
+	font-size: $t-2;
 	display: inline-block;
 	outline: none;
 
@@ -124,7 +124,7 @@ Page Header Component
 .page-header__subnav-link {
 	text-decoration: none;
 	color: #fff;
-	font-size: $t-s;
+	font-size: $t-2;
 	display: inline-block;
 
 	.icon {

--- a/framework/src/scss/components/_popovers.scss
+++ b/framework/src/scss/components/_popovers.scss
@@ -62,7 +62,7 @@ Popover Component
 .popover.has-caret:after {
 	background: #fff;
 	color: $black;
-	transition-duration: $tr-l;
+	transition-duration: $tr-4;
 	transition-timing-function: ease-in-out;
 }
 

--- a/framework/src/scss/components/_tab.scss
+++ b/framework/src/scss/components/_tab.scss
@@ -6,7 +6,7 @@
 	@include link(dark);
 	font-family: $heading;
 	padding: convertScaleToRem(4);
-	font-size: $t-l;
+	font-size: $t-4;
 	display: inline-block;
 
 	&:first-child {

--- a/framework/src/scss/components/_table.scss
+++ b/framework/src/scss/components/_table.scss
@@ -20,7 +20,7 @@ Table
 
 	th {
 		padding: convertScaleToRem(3) convertScaleToRem(4);
-		font-size: $t-l;
+		font-size: $t-4;
 		font-family: $heading;
 		color: $black;
 	}

--- a/framework/src/scss/components/_transitions.scss
+++ b/framework/src/scss/components/_transitions.scss
@@ -17,7 +17,7 @@ Transition Components
 
 // Scale on hover
 .scale-up-hover {
-	transition-duration: $tr-m;
+	transition-duration: $tr-3;
 
 	&:hover, &.is-open {
 		transform: scale(1.1);
@@ -25,7 +25,7 @@ Transition Components
 }
 
 .scale-down-hover {
-	transition-duration: $tr-m;
+	transition-duration: $tr-3;
 
 	&:hover, &.is-open {
 		transform: scale(.95);

--- a/framework/src/scss/style.scss
+++ b/framework/src/scss/style.scss
@@ -13,3 +13,4 @@
 @import 'fonts';
 @import 'components';
 @import 'utilities';
+@import 'deprecate';

--- a/framework/src/scss/utilities/_animations.scss
+++ b/framework/src/scss/utilities/_animations.scss
@@ -17,29 +17,28 @@ Animation Utilities
 
 
 // Duration
-.a-duration-none {
+.a-duration-0 {
   animation-duration: 0s !important;
 }
 
-.a-duration-xs {
-  animation-duration: $a-xs !important;
+.a-duration-1 {
+  animation-duration: $a-1 !important;
 }
 
-.a-duration-s {
-  animation-duration: $a-s !important;
+.a-duration-2 {
+  animation-duration: $a-2 !important;
 }
 
-.a-duration,
-.a-duration-m {
-  animation-duration: $a-m !important;
+.a-duration-3 {
+  animation-duration: $a-3 !important;
 }
 
-.a-duration-l {
-  animation-duration: $a-l !important;
+.a-duration-4 {
+  animation-duration: $a-4 !important;
 }
 
-.a-duration-xl {
-  animation-duration: $a-xl !important;
+.a-duration-5 {
+  animation-duration: $a-5 !important;
 }
 
 

--- a/framework/src/scss/utilities/_animations.scss
+++ b/framework/src/scss/utilities/_animations.scss
@@ -7,7 +7,7 @@ Animation Utilities
   scss/components/_animations.scss.
 
   Usage:
-  <div class="bounce a-duration-l a-easing-cb-scale-out">
+  <div class="bounce a-duration-4 a-easing-cb-scale-out">
     This div bounces slowly with a cubic bezier scaling effect. The initial
     bounce is defined in the components doc, while the utility classes override
     the component's default values.

--- a/framework/src/scss/utilities/_border-radius.scss
+++ b/framework/src/scss/utilities/_border-radius.scss
@@ -8,31 +8,22 @@ Border Radius Utility
 */
 
 .u-border-radius {border-radius: $border-radius !important}
-.u-border-radius-l {border-radius: $border-radius-l !important}
 
 .u-border-radius--top-left {border-radius: $border-radius 0 0 0 !important;}
-.u-border-radius-l--top-left {border-radius: $border-radius-l 0 0 0 !important;}
 
 .u-border-radius--top-right {border-radius: 0 $border-radius 0 0 !important;}
-.u-border-radius-l--top-right {border-radius: 0 $border-radius-l 0 0 !important;}
 
 .u-border-radius--bottom-right {border-radius: 0 0 $border-radius 0 !important;}
-.u-border-radius-l--bottom-right {border-radius: 0 0 $border-radius-l 0 !important;}
 
 .u-border-radius--bottom-left {border-radius: 0 0 0 $border-radius !important;}
-.u-border-radius-l--bottom-left {border-radius: 0 0 0 $border-radius-l !important;}
 
 .u-border-radius--top {border-radius: $border-radius $border-radius 0 0 !important;}
-.u-border-radius-l--top {border-radius: $border-radius-l $border-radius-l 0 0 !important;}
 
 .u-border-radius--right {border-radius: 0 $border-radius $border-radius 0 !important;}
-.u-border-radius-l--right {border-radius: 0 $border-radius-l $border-radius-l 0 !important;}
 
 .u-border-radius--bottom {border-radius: 0 0 $border-radius $border-radius !important;}
-.u-border-radius-l--bottom {border-radius: 0 0 $border-radius-l $border-radius-l !important;}
 
 .u-border-radius--left {border-radius: $border-radius 0 0 $border-radius !important;}
-.u-border-radius-l--left {border-radius: $border-radius-l 0 0 $border-radius-l !important;}
 
 // Shorthand!
 .u-rounded-corners {@extend .u-border-radius}

--- a/framework/src/scss/utilities/_transitions.scss
+++ b/framework/src/scss/utilities/_transitions.scss
@@ -18,12 +18,11 @@ Transition Utilities
 
 // Duration
 .tr-duration-0 {transition-duration: 0s !important;}
-.tr-duration-xs {transition-duration: $tr-xs !important;}
-.tr-duration-s {transition-duration: $tr-s !important;}
-.tr-duration,
-.tr-duration-m {transition-duration: $tr-m !important;}
-.tr-duration-l {transition-duration: $tr-l !important;}
-.tr-duration-xl {transition-duration: $tr-xl !important;}
+.tr-duration-1 {transition-duration: $tr-1 !important;}
+.tr-duration-2 {transition-duration: $tr-2 !important;}
+.tr-duration-3 {transition-duration: $tr-3 !important;}
+.tr-duration-4 {transition-duration: $tr-4 !important;}
+.tr-duration-5 {transition-duration: $tr-5 !important;}
 
 // Easing
 .tr-easing-linear {transition-timing-function: linear !important;}

--- a/framework/src/scss/utilities/_transitions.scss
+++ b/framework/src/scss/utilities/_transitions.scss
@@ -7,7 +7,7 @@ Transition Utilities
   scss/components/_transitions.scss.
 
   Usage:
-  <div class="scale-up-hover tr-duration-large tr-easing-cb-scale-out">
+  <div class="scale-up-hover tr-duration-4 tr-easing-cb-scale-out">
     This div scale up slowly on hover, with a cubic bezier scaling effect. The
     initial scaling up is defined in the components doc, while the utility
     classes override the component's default values.

--- a/framework/src/scss/utilities/_typography.scss
+++ b/framework/src/scss/utilities/_typography.scss
@@ -2,11 +2,12 @@
 .t-body {font-family: $body !important}
 .t-heading {font-family: $heading !important}
 
-.t-xs {font-size: $t-xs !important}
-.t-s {font-size: $t-s !important}
-.t-m {font-size: $t-m !important}
-.t-l {font-size: $t-l !important}
-.t-xl {font-size: $t-xl !important}
+.t-1 {font-size: $t-1 !important}
+.t-2 {font-size: $t-2 !important}
+.t-3 {font-size: $t-3 !important}
+.t-4 {font-size: $t-4 !important}
+.t-5 {font-size: $t-5 !important}
+.t-6 {font-size: $t-6 !important}
 
 // Alignment
 .t-left {text-align: left !important}


### PR DESCRIPTION
This is for #60. I'm also moving this to a 0.1.0 branch. According to semver, this would be a `MINOR version when you add functionality in a backwards-compatible manner`. There is a _deprecated.scss that keeps old classes properly functioning until 1.0.0 where we should remove them completely.