### PR TITLE
Add form active states and some light refactoring.

### DIFF
--- a/docs/components/form/index.md
+++ b/docs/components/form/index.md
@@ -6,16 +6,14 @@ layout: page
 ## Block inputs
 
 <div class="form__group">
-	<label class="form__label">Text label
-		<input type="text" class="form__input" placeholder="Example placeholder content">
-	</label>
+	<label for="input1" class="form__label">Text label</label>
+	<input id="input1" type="text" class="form__input" placeholder="Example placeholder content">
 </div>
 
 {% highlight html %}
 <div class="form__group">
-	<label class="form__label">Text label
-		<input type="text" class="form__input" placeholder="Example placeholder content">
-	</label>
+	<label for="input1" class="form__label">Text label</label>
+	<input id="input1" type="text" class="form__input" placeholder="Example placeholder content">
 </div>
 {% endhighlight %}
 
@@ -25,14 +23,12 @@ layout: page
 	<div class="inline-input-grid">
 		<div class="inline-input-row">
 			<div class="form__group form__group--inline">
-				<label class="form__label">Half label
-					<input type="text" class="form__input" placeholder="Example placeholder content">
-				</label>
+				<label for="input2" class="form__label">Half label</label>
+				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 			<div class="form__group form__group--inline">
-				<label class="form__label">Half label
-					<input type="text" class="form__input" placeholder="Example placeholder content">
-				</label>
+				<label for="input3" class="form__label">Half label</label>
+				<input id="input3" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 		</div>
 	</div>
@@ -43,14 +39,12 @@ layout: page
 	<div class="inline-input-grid">
 		<div class="inline-input-row">
 			<div class="form__group form__group--inline">
-				<label class="form__label">Half label
-					<input type="text" class="form__input" placeholder="Example placeholder content">
-				</label>
+				<label for="input2" class="form__label">Half label</label>
+				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 			<div class="form__group form__group--inline">
-				<label class="form__label">Half label
-					<input type="text" class="form__input" placeholder="Example placeholder content">
-				</label>
+				<label for="input3" class="form__label">Half label</label>
+				<input id="input3" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 		</div>
 	</div>
@@ -60,18 +54,16 @@ layout: page
 ## Textareas
 
 <div class="form__group">
-	<label class="form__label">Text label
-		<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
-		<textarea class="form__input" placeholder="Example placeholder content"></textarea>
-	</label>
+	<label for="textarea1" class="form__label">Text label</label>
+	<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+	<textarea id="textarea1" class="form__input" placeholder="Example placeholder content"></textarea>
 </div>
 
 {% highlight html %}
 <div class="form__group">
-	<label class="form__label">Text label
-		<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
-		<textarea class="form__input" placeholder="Example placeholder content"></textarea>
-	</label>
+	<label for="textarea1" class="form__label">Text label</label>
+	<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+	<textarea id="textarea1" class="form__input" placeholder="Example placeholder content"></textarea>
 </div>
 {% endhighlight %}
 
@@ -213,29 +205,27 @@ layout: page
 
 ## Select menus
 
-<div class="form__group">
-	<label class="form__label select">Select label
-		<select class="form__select">
-			<option>Option 1</option>
-			<option>Option 2</option>
-			<option>Option 3</option>
-			<option>Option 4</option>
-			<option>Option 5</option>
-		</select>
-	</label>
+<div class="form__group form__group--select">
+	<label for="select1" class="form__label">Select label</label>
+	<select id="select1" class="form__select">
+		<option>Option 1</option>
+		<option>Option 2</option>
+		<option>Option 3</option>
+		<option>Option 4</option>
+		<option>Option 5</option>
+	</select>
 </div>
 
 {% highlight html %}
-<div class="form__group">
-	<label class="form__label select">Select label
-		<select class="form__select">
-			<option>Option 1</option>
-			<option>Option 2</option>
-			<option>Option 3</option>
-			<option>Option 4</option>
-			<option>Option 5</option>
-		</select>
-	</label>
+<div class="form__group form__group--select">
+	<label for="select1" class="form__label">Select label</label>
+	<select id="select1" class="form__select">
+		<option>Option 1</option>
+		<option>Option 2</option>
+		<option>Option 3</option>
+		<option>Option 4</option>
+		<option>Option 5</option>
+	</select>
 </div>
 {% endhighlight %}
 

--- a/docs/components/form/index.md
+++ b/docs/components/form/index.md
@@ -19,14 +19,14 @@ layout: page
 
 ## Inline-block inputs
 
-<div class="inline-input-container">
-	<div class="inline-input-grid">
-		<div class="inline-input-row">
-			<div class="form__group form__group--inline">
+<div class="form__group form__group--inline">
+	<div class="form__group--inline-grid">
+		<div class="form__group--inline-row">
+			<div class="form__group">
 				<label for="input2" class="form__label">Half label</label>
 				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
-			<div class="form__group form__group--inline">
+			<div class="form__group">
 				<label for="input3" class="form__label">Half label</label>
 				<input id="input3" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
@@ -35,14 +35,14 @@ layout: page
 </div>
 
 {% highlight html %}
-<div class="inline-input-container">
-	<div class="inline-input-grid">
-		<div class="inline-input-row">
-			<div class="form__group form__group--inline">
+<div class="form__group form__group--inline">
+	<div class="form__group--inline-grid">
+		<div class="form__group--inline-row">
+			<div class="form__group">
 				<label for="input2" class="form__label">Half label</label>
 				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
-			<div class="form__group form__group--inline">
+			<div class="form__group">
 				<label for="input3" class="form__label">Half label</label>
 				<input id="input3" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>

--- a/docs/components/form/index.md
+++ b/docs/components/form/index.md
@@ -2,3 +2,253 @@
 title: Form
 layout: page
 ---
+
+## Block inputs
+
+<div class="form__group">
+	<label class="form__label">Text label
+		<input type="text" class="form__input" placeholder="Example placeholder content">
+	</label>
+</div>
+
+{% highlight html %}
+<div class="form__group">
+	<label class="form__label">Text label
+		<input type="text" class="form__input" placeholder="Example placeholder content">
+	</label>
+</div>
+{% endhighlight %}
+
+## Inline-block inputs
+
+<div class="inline-input-container">
+	<div class="inline-input-grid">
+		<div class="inline-input-row">
+			<div class="form__group form__group--inline">
+				<label class="form__label">Half label
+					<input type="text" class="form__input" placeholder="Example placeholder content">
+				</label>
+			</div>
+			<div class="form__group form__group--inline">
+				<label class="form__label">Half label
+					<input type="text" class="form__input" placeholder="Example placeholder content">
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+
+{% highlight html %}
+<div class="inline-input-container">
+	<div class="inline-input-grid">
+		<div class="inline-input-row">
+			<div class="form__group form__group--inline">
+				<label class="form__label">Half label
+					<input type="text" class="form__input" placeholder="Example placeholder content">
+				</label>
+			</div>
+			<div class="form__group form__group--inline">
+				<label class="form__label">Half label
+					<input type="text" class="form__input" placeholder="Example placeholder content">
+				</label>
+			</div>
+		</div>
+	</div>
+</div>
+{% endhighlight %}
+
+## Textareas
+
+<div class="form__group">
+	<label class="form__label">Text label
+		<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+		<textarea class="form__input" placeholder="Example placeholder content"></textarea>
+	</label>
+</div>
+
+{% highlight html %}
+<div class="form__group">
+	<label class="form__label">Text label
+		<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+		<textarea class="form__input" placeholder="Example placeholder content"></textarea>
+	</label>
+</div>
+{% endhighlight %}
+
+## Simple radios and check boxes
+
+<div class="container-full-width">
+	<div class="form__group g-1_2">
+		<label class="form__label">Radio label</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1" checked>
+			<span class="form__radio-check-label">Example radio label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1">
+			<span class="form__radio-check-label">Example radio label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1">
+			<span class="form__radio-check-label">Example radio label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1">
+			<span class="form__radio-check-label">Example radio label</span>
+		</label>
+	</div>
+
+	<div class="form__group g-1_2">
+		<label class="form__label">Checkbox label</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1" checked>
+			<span class="form__radio-check-label">Example checkbox label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1">
+			<span class="form__radio-check-label">Example checkbox label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1">
+			<span class="form__radio-check-label">Example checkbox label</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1">
+			<span class="form__radio-check-label">Example checkbox label</span>
+		</label>
+	</div>
+</div>
+
+{% highlight html %}
+<div class="form__group g-1_2">
+	<label class="form__label">Radio label</label>
+	<label class="form__radio-check">
+		<input type="radio" name="radio1" checked>
+		<span class="form__radio-check-label">Example radio label</span>
+	</label>
+	<label class="form__radio-check">
+		<input type="radio" name="radio1">
+		<span class="form__radio-check-label">Example radio label</span>
+	</label>
+</div>
+{% endhighlight %}
+
+{% highlight html %}
+<div class="form__group g-1_2">
+	<label class="form__label">Checkbox label</label>
+	<label class="form__radio-check">
+		<input type="checkbox" name="check1" checked>
+		<span class="form__radio-check-label">Example checkbox label</span>
+	</label>
+	<label class="form__radio-check">
+		<input type="checkbox" name="check1">
+		<span class="form__radio-check-label">Example checkbox label</span>
+	</label>
+</div>
+{% endhighlight %}
+
+## Complex radios and checkboxes
+
+<div class="container-full-width">
+	<div class="form__group">
+		<label class="form__label">Radio label</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1" checked>
+			<span class="form__radio-check-label">Example radio label</span>
+			<span class="form__radio-check-description">Help explain what this choice is</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="radio" name="radio1" checked>
+			<span class="form__radio-check-label">Example radio label that is really long and probably wraps really awkwardly</span>
+			<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+		</label>
+	</div>
+
+	<div class="form__group">
+		<label class="form__label">Checkbox label</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1" checked>
+			<span class="form__radio-check-label">Example checkbox label that is really long and probably wraps really awkwardly</span>
+			<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+		</label>
+		<label class="form__radio-check">
+			<input type="checkbox" name="check1">
+			<span class="form__radio-check-label">Example checkbox label that is really long and probably wraps really awkwardly</span>
+			<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+		</label>
+	</div>
+</div>
+
+{% highlight html %}
+<div class="form__group">
+	<label class="form__label">Radio label</label>
+	<label class="form__radio-check">
+		<input type="radio" name="radio1" checked>
+		<span class="form__radio-check-label">Example radio label</span>
+		<span class="form__radio-check-description">Help explain what this choice is</span>
+	</label>
+	<label class="form__radio-check">
+		<input type="radio" name="radio1" checked>
+		<span class="form__radio-check-label">Example radio label that is really long and probably wraps really awkwardly</span>
+		<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+	</label>
+</div>
+{% endhighlight %}
+
+{% highlight html %}
+<div class="form__group">
+	<label class="form__label">Checkbox label</label>
+	<label class="form__radio-check">
+		<input type="checkbox" name="check1" checked>
+		<span class="form__radio-check-label">Example checkbox label that is really long and probably wraps really awkwardly</span>
+		<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+	</label>
+	<label class="form__radio-check">
+		<input type="checkbox" name="check1">
+		<span class="form__radio-check-label">Example checkbox label that is really long and probably wraps really awkwardly</span>
+		<span class="form__radio-check-description">Help explain what this choice is in more text than should be necessary to see how text wraps</span>
+	</label>
+</div>
+{% endhighlight %}
+
+## Select menus
+
+<div class="form__group">
+	<label class="form__label select">Select label
+		<select class="form__select">
+			<option>Option 1</option>
+			<option>Option 2</option>
+			<option>Option 3</option>
+			<option>Option 4</option>
+			<option>Option 5</option>
+		</select>
+	</label>
+</div>
+
+{% highlight html %}
+<div class="form__group">
+	<label class="form__label select">Select label
+		<select class="form__select">
+			<option>Option 1</option>
+			<option>Option 2</option>
+			<option>Option 3</option>
+			<option>Option 4</option>
+			<option>Option 5</option>
+		</select>
+	</label>
+</div>
+{% endhighlight %}
+
+## Submit and cancel buttons
+
+<div class="form__group form__group--actions">
+	<input type="submit" class="btn" value="Submit">
+	<input type="button" class="btn btn--outline" value="Cancel">
+</div>
+
+{% highlight html %}
+<div class="form__group form__group--actions">
+	<input type="submit" class="btn" value="Submit">
+	<input type="button" class="btn btn--outline" value="Cancel">
+</div>
+{% endhighlight %}

--- a/docs/components/form/index.md
+++ b/docs/components/form/index.md
@@ -19,9 +19,9 @@ layout: page
 
 ## Inline-block inputs
 
-<div class="form__group form__group--inline">
-	<div class="form__group--inline-grid">
-		<div class="form__group--inline-row">
+<div class="form__inline">
+	<div class="form__inline-grid">
+		<div class="form__inline-row">
 			<div class="form__group">
 				<label for="input2" class="form__label">Half label</label>
 				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">
@@ -35,9 +35,9 @@ layout: page
 </div>
 
 {% highlight html %}
-<div class="form__group form__group--inline">
-	<div class="form__group--inline-grid">
-		<div class="form__group--inline-row">
+<div class="form__inline">
+	<div class="form__inline-grid">
+		<div class="form__inline-row">
 			<div class="form__group">
 				<label for="input2" class="form__label">Half label</label>
 				<input id="input2" type="text" class="form__input" placeholder="Example placeholder content">

--- a/docs/typography/index.md
+++ b/docs/typography/index.md
@@ -88,8 +88,8 @@ DreamHost uses Ubuntu for headings and Proxima Nova for body text.
 	<p class="t-bold">The quick brown fox jumps over the lazy dog.</p>
 </div>
 <div>
-	<p class="m-bottom-0 t-s t-salmon t-bold">.t-normal</p>
-	<p class="t-normal">The quick brown fox jumps over the lazy dog.</p>
+	<p class="m-bottom-0 t-s t-salmon t-bold">.t-regular</p>
+	<p class="t-regular">The quick brown fox jumps over the lazy dog.</p>
 </div>
 <div>
 	<p class="m-bottom-0 t-s t-salmon t-bold">.t-light</p>
@@ -103,7 +103,7 @@ DreamHost uses Ubuntu for headings and Proxima Nova for body text.
 {% highlight html %}
 <p class="t-extrabold">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-bold">The quick brown fox jumps over the lazy dog.</p>
-<p class="t-normal">The quick brown fox jumps over the lazy dog.</p>
+<p class="t-regular">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-light">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-lighter">The quick brown fox jumps over the lazy dog.</p>
 {% endhighlight %}

--- a/docs/typography/index.md
+++ b/docs/typography/index.md
@@ -80,12 +80,16 @@ DreamHost uses Ubuntu for headings and Proxima Nova for body text.
 ## Weight
 
 <div>
-	<p class="m-bottom-0 t-s t-salmon t-bold">.t-heavy</p>
-	<p class="t-heavy">The quick brown fox jumps over the lazy dog.</p>
+	<p class="m-bottom-0 t-s t-salmon t-bold">.t-extrabold</p>
+	<p class="t-extrabold">The quick brown fox jumps over the lazy dog.</p>
 </div>
 <div>
 	<p class="m-bottom-0 t-s t-salmon t-bold">.t-bold</p>
 	<p class="t-bold">The quick brown fox jumps over the lazy dog.</p>
+</div>
+<div>
+	<p class="m-bottom-0 t-s t-salmon t-bold">.t-normal</p>
+	<p class="t-normal">The quick brown fox jumps over the lazy dog.</p>
 </div>
 <div>
 	<p class="m-bottom-0 t-s t-salmon t-bold">.t-light</p>
@@ -97,8 +101,9 @@ DreamHost uses Ubuntu for headings and Proxima Nova for body text.
 </div>
 
 {% highlight html %}
-<p class="t-heavy">The quick brown fox jumps over the lazy dog.</p>
+<p class="t-extrabold">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-bold">The quick brown fox jumps over the lazy dog.</p>
+<p class="t-normal">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-light">The quick brown fox jumps over the lazy dog.</p>
 <p class="t-lighter">The quick brown fox jumps over the lazy dog.</p>
 {% endhighlight %}

--- a/framework/index.html
+++ b/framework/index.html
@@ -272,9 +272,8 @@
 				</div>
 			</div>
 
-			<div class="form__group">
+			<div class="form__group form__group--select">
 				<label for="selectlabel" class="form__label">Select label</label>
-				<div class="select-icon"></div>
 				<select id="selectlabel" class="form__select">
 					<option>Option 1</option>
 					<option>Option 2</option>

--- a/framework/index.html
+++ b/framework/index.html
@@ -161,18 +161,17 @@
 		<form class="form">
 			<div class="form__group">
 				<label for="textlabel1" class="form__label">Text label</label>
-					<input id="textlabel1" type="text" class="form__input" placeholder="Example placeholder content">
-				</label>
+				<input id="textlabel1" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 
-			<div class="inline-input-container">
-				<div class="inline-input-grid">
-					<div class="inline-input-row">
-						<div class="form__group form__group--inline">
+			<div class="form__group form__group--inline">
+				<div class="form__group--inline-grid">
+					<div class="form__group--inline-row">
+						<div class="form__group">
 							<label for="halflabel1" class="form__label">Half label</label>
-								<input id="halflabel1" type="text" class="form__input" placeholder="Example placeholder content">
+							<input id="halflabel1" type="text" class="form__input" placeholder="Example placeholder content">
 						</div>
-						<div class="form__group form__group--inline">
+						<div class="form__group">
 							<label for="halflabel2" class="form__label">Half label</label>
 							<input id="halflabel2" type="text" class="form__input" placeholder="Example placeholder content">
 						</div>

--- a/framework/index.html
+++ b/framework/index.html
@@ -160,25 +160,33 @@
 
 		<form class="form">
 			<div class="form__group">
-				<label class="form__label">Text label</label>
-				<input type="text" class="form__input" placeholder="Example placeholder content">
+				<label class="form__label">Text label
+					<input type="text" class="form__input" placeholder="Example placeholder content">
+				</label>
 			</div>
 
-			<div class="container-full-width">
-				<div class="form__group g-1_2">
-					<label class="form__label">Half label</label>
-					<input type="text" class="form__input" placeholder="Example placeholder content">
-				</div>
-				<div class="form__group g-1_2">
-					<label class="form__label">Half label</label>
-					<input type="text" class="form__input" placeholder="Example placeholder content">
+			<div class="inline-input-container">
+				<div class="inline-input-grid">
+					<div class="inline-input-row">
+						<div class="form__group form__group--inline">
+							<label class="form__label">Half label
+								<input type="text" class="form__input" placeholder="Example placeholder content">
+							</label>
+						</div>
+						<div class="form__group form__group--inline">
+							<label class="form__label">Half label
+								<input type="text" class="form__input" placeholder="Example placeholder content">
+							</label>
+						</div>
+					</div>
 				</div>
 			</div>
 
 			<div class="form__group">
-				<label class="form__label">Text label</label>
-				<p class="form__description">Put in some text! Only good text, not bad text, obviously. What is this input for? Are there any formatting requirements? This is for a text input so we might need to say a lot of things. There might be some <strong>bolded</strong> text, or maybe <em>italics</em>. Maybe we end with some sort of <a href="#">help link</a>.</p>
-				<textarea class="form__input" placeholder="Example placeholder content"></textarea>
+				<label class="form__label">Text label
+					<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+					<textarea class="form__input" placeholder="Example placeholder content"></textarea>
+				</label>
 			</div>
 
 			<div class="container-full-width">
@@ -262,14 +270,15 @@
 			</div>
 
 			<div class="form__group">
-				<label class="form__label">Select label</label>
-				<select class="form__select">
-					<option>Option 1</option>
-					<option>Option 2</option>
-					<option>Option 3</option>
-					<option>Option 4</option>
-					<option>Option 5</option>
-				</select>
+				<label class="form__label select">Select label
+					<select class="form__select">
+						<option>Option 1</option>
+						<option>Option 2</option>
+						<option>Option 3</option>
+						<option>Option 4</option>
+						<option>Option 5</option>
+					</select>
+				</label>
 			</div>
 
 			<div class="form__group form__group--actions">

--- a/framework/index.html
+++ b/framework/index.html
@@ -160,8 +160,8 @@
 
 		<form class="form">
 			<div class="form__group">
-				<label class="form__label">Text label
-					<input type="text" class="form__input" placeholder="Example placeholder content">
+				<label for="textlabel1" class="form__label">Text label</label>
+					<input id="textlabel1" type="text" class="form__input" placeholder="Example placeholder content">
 				</label>
 			</div>
 
@@ -169,24 +169,27 @@
 				<div class="inline-input-grid">
 					<div class="inline-input-row">
 						<div class="form__group form__group--inline">
-							<label class="form__label">Half label
-								<input type="text" class="form__input" placeholder="Example placeholder content">
-							</label>
+							<label for="halflabel1" class="form__label">Half label</label>
+								<input id="halflabel1" type="text" class="form__input" placeholder="Example placeholder content">
 						</div>
 						<div class="form__group form__group--inline">
-							<label class="form__label">Half label
-								<input type="text" class="form__input" placeholder="Example placeholder content">
-							</label>
+							<label for="halflabel2" class="form__label">Half label</label>
+							<input id="halflabel2" type="text" class="form__input" placeholder="Example placeholder content">
 						</div>
 					</div>
 				</div>
 			</div>
 
+			<div class="form__group form__group--stacked">
+				<label for="stackedlabel" class="form__label">Stacked label</label>
+				<input id="stackedlabel" type="text" class="form__input" placeholder="Example placeholder content">
+				<input type="text" class="form__input" placeholder="Example placeholder content">
+			</div>
+
 			<div class="form__group">
-				<label class="form__label">Text label
-					<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
-					<textarea class="form__input" placeholder="Example placeholder content"></textarea>
-				</label>
+				<label for="textarealabel" class="form__label">Text label</label>
+				<p class="form__description">This caption supports a <strong>non-ludicrous</strong> amount of text. <a href="#">Learn more.</a></p>
+				<textarea id="textarealabel" class="form__input" placeholder="Example placeholder content"></textarea>
 			</div>
 
 			<div class="container-full-width">
@@ -270,15 +273,15 @@
 			</div>
 
 			<div class="form__group">
-				<label class="form__label select">Select label
-					<select class="form__select">
-						<option>Option 1</option>
-						<option>Option 2</option>
-						<option>Option 3</option>
-						<option>Option 4</option>
-						<option>Option 5</option>
-					</select>
-				</label>
+				<label for="selectlabel" class="form__label">Select label</label>
+				<div class="select-icon"></div>
+				<select id="selectlabel" class="form__select">
+					<option>Option 1</option>
+					<option>Option 2</option>
+					<option>Option 3</option>
+					<option>Option 4</option>
+					<option>Option 5</option>
+				</select>
 			</div>
 
 			<div class="form__group form__group--actions">

--- a/framework/index.html
+++ b/framework/index.html
@@ -164,9 +164,9 @@
 				<input id="textlabel1" type="text" class="form__input" placeholder="Example placeholder content">
 			</div>
 
-			<div class="form__group form__group--inline">
-				<div class="form__group--inline-grid">
-					<div class="form__group--inline-row">
+			<div class="form__inline">
+				<div class="form__inline-grid">
+					<div class="form__inline-row">
 						<div class="form__group">
 							<label for="halflabel1" class="form__label">Half label</label>
 							<input id="halflabel1" type="text" class="form__input" placeholder="Example placeholder content">

--- a/framework/src/scss/_defaults.scss
+++ b/framework/src/scss/_defaults.scss
@@ -76,7 +76,7 @@ hr {
 
 code {
 	padding: 0 convertScaleToRem(1);
-	font-size: $t-2;
+	font-size: $t-3;
 	display: inline-block;
 	border: 1px solid $lighter-grey;
 	border-radius: $border-radius;

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -88,8 +88,9 @@ $t-1: .75em; // 12px
 // Font weight
 $t-lighter: 100;
 $t-light: 300;
+$t-regular: 500;
 $t-bold: 700;
-$t-heavy: 900;
+$t-extrabold: 900;
 
 // Borders
 $border-radius: 3px;

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -19,29 +19,27 @@ Form Component
 .form {}
 
 .form__group {
-	margin-bottom: convertScaleToRem(4);
-}
-
-.inline-input-container {
 	max-width: 100%;
 	margin: 0 auto 2rem;
 }
 
-.inline-input-grid {
+.form__group--inline {
+	.form__group {
+		display: table-cell;
+		vertical-align: top;
+	}
+}
+
+.form__group--inline-grid {
 	margin: 0 -2rem;
 }
 
-.inline-input-row {
+.form__group--inline-row {
 	display: table;
 	table-layout: fixed;
 	width: 100%;
 	border-collapse: separate;
 	border-spacing: 2rem 0;
-}
-
-.form__group--inline {
-	display: table-cell;
-	vertical-align: top;
 }
 
 .form__group--actions {
@@ -167,7 +165,6 @@ textarea.form__input {
 
 .form__group--select {
 	position: relative;
-	top: -1.5rem;
 
 	&:after {
 		content: '';

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -23,18 +23,20 @@ Form Component
 	margin: 0 auto 2rem;
 }
 
-.form__group--inline {
+.form__inline {
+		margin: 0 auto 2rem;
+
 	.form__group {
 		display: table-cell;
 		vertical-align: top;
 	}
 }
 
-.form__group--inline-grid {
+.form__inline-grid {
 	margin: 0 -2rem;
 }
 
-.form__group--inline-row {
+.form__inline-row {
 	display: table;
 	table-layout: fixed;
 	width: 100%;

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -29,7 +29,6 @@ Form Component
 .inline-input-container {
 	max-width: 100%;
 	margin: 0 auto 2rem;
-	overflow: hidden;
 }
 
 .inline-input-grid {

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -7,7 +7,7 @@ Form Component
 %form-border { border: 1px solid $light-grey; }
 %form-description {
 	color: $dark-grey;
-	font-size: $t-2;
+	font-size: $t-3;
 }
 %form-no-outline { outline: none; }
 %form-text-style {
@@ -26,6 +26,29 @@ Form Component
 	}
 }
 
+.inline-input-container {
+	max-width: 100%;
+	margin: 0 auto 2rem;
+	overflow: hidden;
+}
+
+.inline-input-grid {
+	margin: 0 -2rem;
+}
+
+.inline-input-row {
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	border-collapse: separate;
+	border-spacing: 2rem 0;
+}
+
+.form__group--inline {
+	display: table-cell;
+	vertical-align: top;
+}
+
 .form__group--actions {
 	margin-top: convertScaleToRem(6);
 
@@ -34,17 +57,16 @@ Form Component
 .form__label {
 	color: $darker-grey;
 	display: block;
-	font-size: $t-2;
+	font-size: $t-3;
 	font-weight: $t-bold;
-	margin-bottom: convertScaleToRem(1);
+	cursor: pointer;
 }
 
 .form__description {
 	@extend %form-description;
 
-	margin-top: -(convertScaleToRem(1)); // Haha. Reverse margin to unset .form__label's bottom margin.
-	margin-bottom: convertScaleToRem(2);
-	max-width: 35em; // Should give this a good width to break at
+	font-weight: $t-regular;
+	margin-bottom: 0;
 }
 
 .form__input {
@@ -54,14 +76,36 @@ Form Component
 
 	display: block;
 	margin: 0;
+	margin-top: .5rem;
 	width: 100%;
 
 	border-radius: $border-radius;
 	padding: .65rem;
 
+	&:active,
+	&:focus {
+		box-shadow: 2px 2px 0 0 $light-grey;
+		&::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+			color: $white;
+		}
+		&::-moz-placeholder { /* Firefox 19+ */
+			color: $white;
+		}
+		&:-ms-input-placeholder { /* IE 10+ */
+			color: $white;
+		}
+		&:-moz-placeholder { /* Firefox 18- */
+			color: $white;
+		}
+	}
+
 	&::placeholder {
 		color: $dark-grey;
 	}
+}
+
+.form__label > .form__description {
+	margin-bottom: 1rem;
 }
 
 textarea.form__input {
@@ -104,8 +148,36 @@ textarea.form__input {
 	@extend %form-no-outline;
 	@extend %form-text-style;
 
+	border-radius: $border-radius;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	padding: 0 0 0 .75rem;
+	background: $lighter-grey; /* Old browsers */
+	background: -moz-linear-gradient(top, $lighter-grey 0%, lighten($lighter-grey, 2%) 100%); /* FF3.6-15 */
+	background: -webkit-linear-gradient(top, $lighter-grey 0%, lighten($lighter-grey, 2%) 100%); /* Chrome10-25, Safari5.1-6 */
+	background: linear-gradient(to bottom, $lighter-grey 0%, lighten($lighter-grey, 2%) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='$lighter-grey', endColorstr='lighten($lighter-grey, 3%)', GradientType=0 ); /* IE6-9 */
 	display: block;
 	width: 100%;
 	height: 42px;
 	line-height: 42px;
+	cursor: pointer;
+}
+
+.select {
+	position: relative;
+
+	&:after {
+		content: '';
+		position: absolute;
+		top: 2.7rem;
+		right: 1rem;
+		border-color: $grey transparent;
+		border-style: solid;
+		border-width: .35rem .35rem 0 .35rem;
+	}
+
+	&:hover:after {
+		border-color: $dark-grey transparent;
+	}
 }

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -165,7 +165,7 @@ textarea.form__input {
 	cursor: pointer;
 }
 
-.select-icon {
+.form__group--select {
 	position: relative;
 	top: -1.5rem;
 
@@ -178,8 +178,8 @@ textarea.form__input {
 		border-style: solid;
 		border-width: .35rem .35rem 0 .35rem;
 	}
-}
 
-.form__group:hover > .select-icon:after {
-	border-color: $dark-grey transparent;
+	&:hover:after {
+		border-color: $dark-grey transparent;
+	}
 }

--- a/framework/src/scss/components/_forms.scss
+++ b/framework/src/scss/components/_forms.scss
@@ -20,10 +20,6 @@ Form Component
 
 .form__group {
 	margin-bottom: convertScaleToRem(4);
-
-	& + & {
-		margin-bottom: 0;
-	}
 }
 
 .inline-input-container {
@@ -50,7 +46,12 @@ Form Component
 
 .form__group--actions {
 	margin-top: convertScaleToRem(6);
+}
 
+.form__group--stacked {
+	.form__input + .form__input {
+		margin-top: 1rem;
+	}
 }
 
 .form__label {
@@ -59,6 +60,7 @@ Form Component
 	font-size: $t-3;
 	font-weight: $t-bold;
 	cursor: pointer;
+	max-width: 35rem;
 }
 
 .form__description {
@@ -163,8 +165,9 @@ textarea.form__input {
 	cursor: pointer;
 }
 
-.select {
+.select-icon {
 	position: relative;
+	top: -1.5rem;
 
 	&:after {
 		content: '';
@@ -175,8 +178,8 @@ textarea.form__input {
 		border-style: solid;
 		border-width: .35rem .35rem 0 .35rem;
 	}
+}
 
-	&:hover:after {
-		border-color: $dark-grey transparent;
-	}
+.form__group:hover > .select-icon:after {
+	border-color: $dark-grey transparent;
 }

--- a/framework/src/scss/utilities/_typography.scss
+++ b/framework/src/scss/utilities/_typography.scss
@@ -16,7 +16,7 @@
 .t-justify {text-align: justify !important}
 
 // Weights
-.t-heavy {font-weight: $t-heavy !important}
+.t-extrabold {font-weight: $t-extrabold !important}
 .t-bold {font-weight: $t-bold !important}
 .t-light {font-weight: $t-light !important}
 .t-lighter {font-weight: $t-lighter !important}


### PR DESCRIPTION
**Change "Heavy" to "Extrabold"**
This feels more consistent with the normal font weight scale

**Add `$t-regular` for 500 weight font**
Should be self explanatory

**Change code, input label, and input description font sizes to `1rem`**
I noticed that with the smaller label and input font sizes it is very easy to have many font sizes in a small space. Example here: http://fowl.es/1p2e2t0n231C. By making those font sizes the same as the default (`1rem`), it simplifies the UI in terms of various font sizes in condensed spaces, makes everything slightly more readable, and helps with hierarchy (where parents don't appear to be smaller than children).

**Add `for`/ `id` attributes to all labels/inputs respectively**
Some users have shaky hands. This lets users also click the labels to type into inputs.

**Reduce total amount of label text possible**
This isn't really a code change, but a demo change. Lack of brevity in input labels ignores modality. When users are filling out inputs, they're in `action` mode. When they are reading paragraphs of text, they are in `learning` mode. That's why solutions like linking out to more info or leveraging modals are generally more usable within forms. Thus, the revision depicts a link to more info instead.

**Add active state to text inputs**
They should now get `box-shadow` on active/focus

**Add select input icon**
Using a down arrow, instead of up/down arrow. The up/down arrow is only an accurate depiction of what occurs on macs. The down arrow, however, ubiquitously works as a dropdown signifier across platforms. This is also consistent with how we already signify other dropdown components throughout the panel, such as popovers.

**Make select input border-radius consistent**
It was `5px`. Now it's `3px` like everything else.

**Add hover state to select inputs**
The arrow indicator darkens slightly on hover

**Hide input placeholders on active state**
This can help users understand that they should start typing, instead of assuming that the placeholder text is already typed.

**Add `.form__inline` classes for inputs that appear inline**
This keeps middle margins consistent with side margins. Right now, the middle margins are calculated using percentages. That creates an inconsistency against the side margins when the page scales below 100% width. This revision ensures that the middle margins always stay at `2rem` which is also how the side margins behave.

Here are a couple of vids demonstrating these changes:
http://fowl.es/0X2u1y1C3t10
http://fowl.es/0V3m2n3R0N0w