### PR TITLE
Word break

### DIFF
--- a/framework/src/scss/utilities/_word-break.scss
+++ b/framework/src/scss/utilities/_word-break.scss
@@ -1,2 +1,2 @@
 .u-wb-normal { word-break: normal; }
-.u-wb-break-word { word-break: break-all; word-break: break-word; }
+.u-wb-break-all { word-break: break-all; word-break: break-word; }

--- a/framework/src/scss/utilities/_word-break.scss
+++ b/framework/src/scss/utilities/_word-break.scss
@@ -1,0 +1,2 @@
+.u-wb-normal { word-break: normal; }
+.u-wb-break-word { word-break: break-all; word-break: break-word; }


### PR DESCRIPTION
Basic word-break utility. Class naming follows same convention as whitespace utility.

Note for `u-wb-break-all`, the `break-word` covers webkit exceptions, while `break-all` is the default and fallback that should work everywhere else.