### PR TITLE
Borders

### DIFF
--- a/framework/index.html
+++ b/framework/index.html
@@ -688,6 +688,41 @@
 		</div>
 	</section>
 
+	<section>
+		<h1>Borders</h1>
+		<div class="container-m">
+			<div class="g-1_4 box m-bottom-4 border-top">
+				<p>Top border</p>
+			</div>
+
+			<div class="g-1_4 box m-bottom-4 border-bottom">
+				<p>Bottom border</p>
+			</div>
+
+			<div class="g-1_4 box m-bottom-4 border-left">
+				<p>Left border</p>
+			</div>
+
+			<div class="g-1_4 g-omega box m-bottom-4 border-right">
+				<p>Right border</p>
+			</div>
+		</div>
+
+		<div class="container-m">
+			<div class="g-1_3 box m-bottom-4 border">
+				<p>Default/Solid border</p>
+			</div>
+
+			<div class="g-1_3 box m-bottom-4 border border-dashed">
+				<p>Dashed border</p>
+			</div>
+
+			<div class="g-1_3 g-omega box m-bottom-4 border border-dotted">
+				<p>Dotted border</p>
+			</div>
+		</div>
+	</section>
+
 	<section class="container-m">
 		<h1>Border Radius</h1>
 		<div class="g-1_3 box m-bottom-4 bg-dark-grey">

--- a/framework/src/scss/_variables.scss
+++ b/framework/src/scss/_variables.scss
@@ -92,7 +92,8 @@ $t-extrabold: 900;
 $border-radius: 3px;
 
 // Border size
-$border-size: 2px;
+$border-size-1: 1px;
+$border-size-2: 2px;
 
 // Animation Duration
 $a-5: 2s;

--- a/framework/src/scss/utilities/_borders.scss
+++ b/framework/src/scss/utilities/_borders.scss
@@ -17,10 +17,44 @@
 .border {@extend .border-1; @extend .border-solid;}
 
 // directions
-.border-top {@extend .border-top-1; @extend .border-solid;}
-.border-bottom {@extend .border-bottom-1; @extend .border-solid;}
-.border-left {@extend .border-left-1; @extend .border-solid;}
-.border-right {@extend .border-right-1; @extend .border-solid;}
+.border-top {@extend .border-top-1; @extend .border-top-solid;}
+.border-bottom {@extend .border-bottom-1; @extend .border-bottom-solid;}
+.border-left {@extend .border-left-1; @extend .border-left-solid;}
+.border-right {@extend .border-right-1; @extend .border-right-solid;}
+
+// styles
+.border-solid {border-style: solid}
+.border-top-solid {border-top-style: solid}
+.border-bottom-solid {border-bottom-style: solid}
+.border-left-solid {border-left-style: solid}
+.border-right-solid {border-right-style: solid}
+
+.border-dashed {border-style: dashed}
+.border-top-dashed {border-top-style: dashed}
+.border-bottom-dashed {border-bottom-style: dashed}
+.border-left-dashed {border-left-style: dashed}
+.border-right-dashed {border-right-style: dashed}
+
+.border-dotted {border-style: dotted}
+.border-top-dotted {border-top-style: dotted}
+.border-bottom-dotted {border-bottom-style: dotted}
+.border-left-dotted {border-left-style: dotted}
+.border-right-dotted {border-right-style: dotted}
+
+// widths
+// zero widths to override an element with default styling
+// like an input, or to cancel individual border directions
+.border-none {border-width: 0}
+.border-top-none {border-top-width: 0}
+.border-bottom-none {border-bottom-width: 0}
+.border-left-none {border-left-width: 0}
+.border-right-none {border-right-width: 0}
+
+.border-1 {border-width: $border-size}
+.border-top-1 {border-top-width: $border-size}
+.border-bottom-1 {border-bottom-width: $border-size}
+.border-left-1 {border-left-width: $border-size}
+.border-right-1 {border-right-width: $border-size}
 
 // colors
 .border-black {border-color: $black}
@@ -39,23 +73,3 @@
 .border-grey {border-color: $grey}
 .border-dark-grey {border-color: $dark-grey}
 .border-darker-grey {border-color: $darker-grey}
-
-// styles
-.border-solid {border-style: solid}
-.border-dashed {border-style: dashed}
-.border-dotted {border-style: dotted}
-
-// widths
-// zero widths to override an element with default styling
-// like an input, or to cancel individual border directions
-.border-none {border-width: 0}
-.border-top-none {border-top-width: 0}
-.border-bottom-none {border-bottom-width: 0}
-.border-left-none {border-left-width: 0}
-.border-right-none {border-right-width: 0}
-
-.border-1 {border-width: $border-size}
-.border-top-1 {border-top-width: $border-size}
-.border-bottom-1 {border-bottom-width: $border-size}
-.border-left-1 {border-left-width: $border-size}
-.border-right-1 {border-right-width: $border-size}

--- a/framework/src/scss/utilities/_borders.scss
+++ b/framework/src/scss/utilities/_borders.scss
@@ -44,11 +44,11 @@
 // widths
 // zero widths to override an element with default styling
 // like an input, or to cancel individual border directions
-.border-none {border-width: 0}
-.border-top-none {border-top-width: 0}
-.border-bottom-none {border-bottom-width: 0}
-.border-left-none {border-left-width: 0}
-.border-right-none {border-right-width: 0}
+.border-none, .border-0 {border-width: 0; border-style: none}
+.border-top-none, .border-top-0 {border-top-width: 0; border-top-style: none}
+.border-bottom-none, .border-bottom-0 {border-bottom-width: 0; border-bottom-style: none}
+.border-left-none, .border-left-0 {border-left-width: 0; border-left-style: none}
+.border-right-none, .border-right-0 {border-right-width: 0; border-right-style: none}
 
 .border-1 {border-width: $border-size-1}
 .border-top-1 {border-top-width: $border-size-1}

--- a/framework/src/scss/utilities/_borders.scss
+++ b/framework/src/scss/utilities/_borders.scss
@@ -50,11 +50,17 @@
 .border-left-none {border-left-width: 0}
 .border-right-none {border-right-width: 0}
 
-.border-1 {border-width: $border-size}
-.border-top-1 {border-top-width: $border-size}
-.border-bottom-1 {border-bottom-width: $border-size}
-.border-left-1 {border-left-width: $border-size}
-.border-right-1 {border-right-width: $border-size}
+.border-1 {border-width: $border-size-1}
+.border-top-1 {border-top-width: $border-size-1}
+.border-bottom-1 {border-bottom-width: $border-size-1}
+.border-left-1 {border-left-width: $border-size-1}
+.border-right-1 {border-right-width: $border-size-1}
+
+.border-2 {border-width: $border-size-2}
+.border-top-2 {border-top-width: $border-size-2}
+.border-bottom-2 {border-bottom-width: $border-size-2}
+.border-left-2 {border-left-width: $border-size-2}
+.border-right-2 {border-right-width: $border-size-2}
 
 // colors
 .border-black {border-color: $black}


### PR DESCRIPTION
Hey! Borders are broken! And guess who broke them! (Or didn't make them right in the first place.)

This should fix the border utility so it'll work as intended. The problem was that border styles need to be declared directionally, e.g. `border-bottom` style must be set with `border-bottom-style`, not just global `border-style` or else you'll get the 3 other borders showing up at times. (I know, it's weird.)

Also, since 1px borders are used pretty regularly, that size was added to our variables (2px is still an option).