### PR TITLE
Remove leading comments from compiled CSS file.

### DIFF
--- a/src/scss/_reset.scss
+++ b/src/scss/_reset.scss
@@ -1,8 +1,3 @@
-/* http://meyerweb.com/eric/tools/css/reset/
-   v2.0 | 20110126
-   License: none (public domain)
-*/
-
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,
@@ -23,7 +18,6 @@ time, mark, audio, video {
 	font: inherit;
 	vertical-align: baseline;
 }
-/* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,9 +1,3 @@
-/*
-
-	dreamhost.css
-
-*/
-
 @import 'reset';
 @import 'vendor';
 @import 'variables';


### PR DESCRIPTION
CSS stylesheet starting with comments might be breaking the CSS on some dev sites.